### PR TITLE
Fix relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ More Videos:
 # Getting Started
 These instructions will get you a copy of the project up and running on your local machine for testing purposes.
 
+Define the environment variable inside your *.bashrc* file:
+```
+export SEROW_PATH=<path-to-serow-package>
+```
 ## Prerequisites
 * [Eigen](https://eigen.tuxfamily.org/dox/index.html) 3.3.0 and later
 * [Pinocchio](https://github.com/stack-of-tasks/pinocchio) 2.2.1 and later

--- a/config/go1.json
+++ b/config/go1.json
@@ -7,7 +7,7 @@
       "2": "RL_foot",
       "3": "RR_foot"
   },
-  "model_path": "../../urdf/go1.urdf",
+  "model_path": "go1.urdf",
   "mass": 12,
   "g": 9.81,
   "joint_rate": 400,

--- a/config/go2.json
+++ b/config/go2.json
@@ -7,7 +7,7 @@
         "2": "RL_foot",
         "3": "RR_foot"
     },
-    "model_path": "../../urdf/go2.urdf",
+    "model_path": "go2.urdf",
     "mass": 15.017,
     "g": 9.81,
     "joint_rate": 500,

--- a/config/nao.json
+++ b/config/nao.json
@@ -5,7 +5,7 @@
         "0": "l_ankle",
         "1": "r_ankle"
     },
-    "model_path": "../urdf/nao.urdf",
+    "model_path": "nao.urdf",
     "mass": 5.14,
     "g": 9.81,
     "joint_rate": 100,

--- a/core/src/Serow.cpp
+++ b/core/src/Serow.cpp
@@ -505,15 +505,12 @@ std::optional<State> Serow::getState(bool allow_invalid) {
 
 std::string Serow::findFilepath(const std::string& filename){
     if (std::getenv("SEROW_PATH") == nullptr){
-        throw std::runtime_error("SEROW_PATH environmental variable not set.");  
+        throw std::runtime_error("Environmental variable SEROW_PATH is not set.");  
         return "";
     }
 
-
-    std::string serow_path_env = std::getenv("SEROW_PATH");
+    std::string_view serow_path_env = std::getenv("SEROW_PATH");
     for (const auto& entry: std::filesystem::recursive_directory_iterator(serow_path_env)){
-        std::cout << "Found file --> " << entry.path().string() << '\n';
-
         if (std::filesystem::is_regular_file(entry) && entry.path().filename() == filename){
             return entry.path().string();
         }

--- a/core/src/Serow.hpp
+++ b/core/src/Serow.hpp
@@ -25,6 +25,8 @@
 #include "Measurement.hpp"
 #include "RobotKinematics.hpp"
 #include "State.hpp"
+#include <filesystem> 
+
 
 namespace serow {
 
@@ -113,6 +115,7 @@ class Serow {
     size_t cycle_{};
     size_t imu_calibration_cycles_{};
     std::optional<TerrainMeasurement> terrain_ = std::nullopt;
+    std::string findFilepath(const std::string& filename);
 };
 
 }  // namespace serow

--- a/ros/serow_ros2/src/driver.cpp
+++ b/ros/serow_ros2/src/driver.cpp
@@ -133,7 +133,7 @@ int main(int argc, char* argv[]) {
     force_torque_state_topics.push_back("/left_leg/force_torque_states");
     force_torque_state_topics.push_back("/right_leg/force_torque_states");
     rclcpp::spin(std::make_shared<SerowDriver>("/joint_states", "/imu0", force_torque_state_topics,
-                                               "../config/nao.json"));
+                                               "nao.json"));
     rclcpp::shutdown();
     return 0;
 }

--- a/test/go1_test.cpp
+++ b/test/go1_test.cpp
@@ -24,7 +24,7 @@ constexpr bool kStorePredictions = true; // If true the serow base estimates are
 
 
 TEST(SerowTests, Go1Test) {
-    serow::Serow SEROW("../../config/go1.json");
+    serow::Serow SEROW("go1.json");
     const double mass = 12;                // kg
     const double g = 9.81;                 // m/s^2
     const double mg = mass * g;            // N

--- a/test/go2_test.cpp
+++ b/test/go2_test.cpp
@@ -24,7 +24,7 @@ constexpr bool kStorePredictions = true; // If true the serow base estimates are
 
 
 TEST(SerowTests, Go2Test) {
-    serow::Serow SEROW("../../config/go2.json");
+    serow::Serow SEROW("go2.json");
     const double mass = 15.017;             // kg
     const double g = 9.81;                 // m/s^2
     const double mg = mass * g;            // N

--- a/test/nao_test.cpp
+++ b/test/nao_test.cpp
@@ -19,7 +19,7 @@
 #include <string>
 
 TEST(SerowTests, NaoTest) {
-    serow::Serow SEROW("../../config/nao.json");
+    serow::Serow SEROW("nao.json");
 
     Eigen::Vector3d g = Eigen::Vector3d(0, 0, -9.81);
     serow::ImuMeasurement imu;

--- a/test/scripts/plot_grf_data.py
+++ b/test/scripts/plot_grf_data.py
@@ -3,7 +3,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import yaml
 
-config_filename = "plot_config.yaml"
+config_filename = "plot_grf_config.yaml"
 
 with open(config_filename, "r") as file:
     config_options = yaml.load(file, Loader=yaml.FullLoader)


### PR DESCRIPTION
### Description 
* Added env variable to .bashrc + added instructions in Getting Started of README.md
* Changed all the .json to simply mention the name of the urdf not the relative path
* Added a new function with error handling in Serow that finds the absolute path for the urdf inside the serow package
* ROS node runs since I input simply the nao.json
* Changed the name of the config file in the plot_grf_data.py


### Known issues
This is not generic enough since it only searches the serow package for the .json and urdf. So if a user wants to use its own urdf we will need to modify the serow class to accept the absolute path for the custom urdf file. 