### PR TITLE
Fixed serow-hypertuner compilation issue 

### DIFF
--- a/serow_hypertuner/include/BayesOptimizer.hpp
+++ b/serow_hypertuner/include/BayesOptimizer.hpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include "serow/Serow.hpp"
 #include "serow/lie.hpp"
+// Don't change the order of these includes, they break boost
 #include <bayesopt/parameters.hpp>
 #include <bayesopt/bayesopt.hpp>
 

--- a/serow_hypertuner/include/BayesOptimizer.hpp
+++ b/serow_hypertuner/include/BayesOptimizer.hpp
@@ -4,12 +4,12 @@
 #include <DataManager.hpp>
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
-#include <bayesopt/bayesopt.hpp>
-#include <bayesopt/parameters.hpp>
 #include <cstdio>
 #include <iostream>
 #include "serow/Serow.hpp"
 #include "serow/lie.hpp"
+#include <bayesopt/parameters.hpp>
+#include <bayesopt/bayesopt.hpp>
 
 using vectord = bayesopt::vectord;
 using json = nlohmann::ordered_json;


### PR DESCRIPTION
Fixed the compilation error by changing the order of includes in BayesOptimizer.hpp. The issue is caused probably from macro definition conflict between pinocchio and boost. 